### PR TITLE
HOTFIX: typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1]
+
+### Fixed
+- Fixed typo and unexpected behavior of `selectorsUsage` flag when `options` argument is not an object
+
+
 ## [1.4.0]
 
 ### Added
@@ -24,8 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `selectors.maxPerRuleList` metric
 - Added `keyframes.definedAnimations` metric
 - Added `animations.withoutDefinitions` metric
-
-### Changed
 
 ### Fixed
 - Corrected `selectors.specificity.average` metric

--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ export default function scancss(src, options) {
 
 			report.selectors.unique = Object.keys(report.selectors.usage).length;
 
-			if (options.selectorsUsage === false) {
+			if (scancssOptions.selectorsUsage === false) {
 				report.selectors.usage = {};
 			}
 		}


### PR DESCRIPTION
## [1.4.1]

### Fixed
- Fixed typo and unexpected behavior of `selectorsUsage` flag when `options` argument is not an object
